### PR TITLE
Update proc-macro2 crate to resolve build error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,9 +668,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
`master` doesn't build at the moment due to using an old version of proc_macro2. [Upstream bug report](https://github.com/dtolnay/proc-macro2/issues/356) for comparison.

A quick `cargo update proc-macro2` resolves this.