### PR TITLE
Add Vapoursynth decoding support to allow for avoiding piping

### DIFF
--- a/.github/workflows/av-scenechange.yml
+++ b/.github/workflows/av-scenechange.yml
@@ -83,17 +83,11 @@ jobs:
                       Select-Object -Last 1
           echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Install VapourSynth
-        uses: rlaphoenix/install-vapoursynth-action@v2.1.1
-        with:
-          version: 66
-          cache: true
-
       - name: Build
-        run: cargo build --all-features --tests --benches
+        run: cargo build --features binary,devel,tracing,serialize --tests --benches
 
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test --features binary,devel,tracing,serialize
 
       - name: Generate docs
-        run: cargo doc --all-features --no-deps
+        run: cargo doc --features binary,devel,tracing,serialize --no-deps

--- a/.github/workflows/av-scenechange.yml
+++ b/.github/workflows/av-scenechange.yml
@@ -9,41 +9,38 @@ on:
       - master
 
 jobs:
-
   clippy-rustfmt:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install stable
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: clippy, rustfmt
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
 
-    - name: Install nasm
-      env:
-        LINK: http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm
-        NASM_VERSION: 2.15.05-1
-        NASM_SHA256: >-
-          c860caec653b865d5b83359452d97b11f1b3ba5b18b07cac554cf72550b3bfc9
-      run: |
-        curl -O "$LINK/nasm_${NASM_VERSION}_amd64.deb"
-        echo "$NASM_SHA256 nasm_${NASM_VERSION}_amd64.deb" | sha256sum --check
-        sudo dpkg -i "nasm_${NASM_VERSION}_amd64.deb"
+      - name: Install nasm
+        env:
+          LINK: http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm
+          NASM_VERSION: 2.15.05-1
+          NASM_SHA256: >-
+            c860caec653b865d5b83359452d97b11f1b3ba5b18b07cac554cf72550b3bfc9
+        run: |
+          curl -O "$LINK/nasm_${NASM_VERSION}_amd64.deb"
+          echo "$NASM_SHA256 nasm_${NASM_VERSION}_amd64.deb" | sha256sum --check
+          sudo dpkg -i "nasm_${NASM_VERSION}_amd64.deb"
 
-    - name: Run rustfmt
-      run: |
-        cargo fmt -- --check --verbose
+      - name: Run rustfmt
+        run: |
+          cargo fmt -- --check --verbose
 
-    - name: Run clippy
-      uses: clechasseur/rs-clippy-check@v3
-      with:
-        args: -- -D warnings --verbose -A clippy::wrong-self-convention -A clippy::many_single_char_names -A clippy::upper-case-acronyms
+      - name: Run clippy
+        uses: clechasseur/rs-clippy-check@v3
+        with:
+          args: -- -D warnings --verbose -A clippy::wrong-self-convention -A clippy::many_single_char_names -A clippy::upper-case-acronyms
 
   build:
-
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
@@ -51,46 +48,52 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install stable
-      uses: dtolnay/rust-toolchain@stable
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
 
-    - name: Install nasm for Ubuntu
-      if: matrix.platform == 'ubuntu-latest'
-      env:
-        LINK: http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm
-        NASM_VERSION: 2.15.05-1
-        NASM_SHA256: >-
-          c860caec653b865d5b83359452d97b11f1b3ba5b18b07cac554cf72550b3bfc9
-      run: |
-        curl -O "$LINK/nasm_${NASM_VERSION}_amd64.deb"
-        echo "$NASM_SHA256 nasm_${NASM_VERSION}_amd64.deb" | sha256sum --check
-        sudo dpkg -i "nasm_${NASM_VERSION}_amd64.deb"
+      - name: Install nasm for Ubuntu
+        if: matrix.platform == 'ubuntu-latest'
+        env:
+          LINK: http://debian-archive.trafficmanager.net/debian/pool/main/n/nasm
+          NASM_VERSION: 2.15.05-1
+          NASM_SHA256: >-
+            c860caec653b865d5b83359452d97b11f1b3ba5b18b07cac554cf72550b3bfc9
+        run: |
+          curl -O "$LINK/nasm_${NASM_VERSION}_amd64.deb"
+          echo "$NASM_SHA256 nasm_${NASM_VERSION}_amd64.deb" | sha256sum --check
+          sudo dpkg -i "nasm_${NASM_VERSION}_amd64.deb"
 
-    - name: Install nasm for Windows
-      if: matrix.platform == 'windows-latest'
-      run: |
-        $NASM_VERSION="2.15.05"
-        $LINK="https://www.nasm.us/pub/nasm/releasebuilds/$NASM_VERSION/win64"
-        curl -LO "$LINK/nasm-$NASM_VERSION-win64.zip"
-        7z e -y "nasm-$NASM_VERSION-win64.zip" -o"C:\nasm"
-        echo "C:\nasm" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install nasm for Windows
+        if: matrix.platform == 'windows-latest'
+        run: |
+          $NASM_VERSION="2.15.05"
+          $LINK="https://www.nasm.us/pub/nasm/releasebuilds/$NASM_VERSION/win64"
+          curl -LO "$LINK/nasm-$NASM_VERSION-win64.zip"
+          7z e -y "nasm-$NASM_VERSION-win64.zip" -o"C:\nasm"
+          echo "C:\nasm" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-    - name: Set MSVC x86_64 linker path
-      if: matrix.platform == 'windows-latest'
-      run: |
-        $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
-        $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
-        $LinkPath = vswhere -latest -products * -find "$LinkGlob" |
-                    Select-Object -Last 1
-        echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Set MSVC x86_64 linker path
+        if: matrix.platform == 'windows-latest'
+        run: |
+          $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
+          $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+          $LinkPath = vswhere -latest -products * -find "$LinkGlob" |
+                      Select-Object -Last 1
+          echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-    - name: Build
-      run: cargo build --all-features --tests --benches
+      - name: Install VapourSynth
+        uses: rlaphoenix/install-vapoursynth-action@v2.1.1
+        with:
+          version: 66
+          cache: true
 
-    - name: Run tests
-      run: cargo test --all-features
+      - name: Build
+        run: cargo build --all-features --tests --benches
 
-    - name: Generate docs
-      run: cargo doc --all-features --no-deps
+      - name: Run tests
+        run: cargo test --all-features
+
+      - name: Generate docs
+        run: cargo doc --all-features --no-deps

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 /.idea
+/.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
+ "vapoursynth",
  "y4m",
 ]
 
@@ -116,6 +117,12 @@ dependencies = [
  "num-rational",
  "v_frame",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitstream-io"
@@ -916,6 +923,28 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vapoursynth"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7df702c65dec1cfa3b93f824a1e58d5b0fdb82ac8a722596f43d7214282f56"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "lazy_static",
+ "thiserror",
+ "vapoursynth-sys",
+]
+
+[[package]]
+name = "vapoursynth-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc59bbb7980ce21ece45bc5b3e316bf27ac164b7b1c273ce4846c29d0642a9c"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ clap = { version = "4.0.22", optional = true, features = ["derive"] }
 serde = { version = "1.0.123", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.62", optional = true }
 rav1e = { version = "0.7.0", default-features = false, features = [
-    "asm",
-    "scenechange",
-    "threading",
+  "asm",
+  "scenechange",
+  "threading",
 ] }
 log = { version = "0.4.14", optional = true }
 console = { version = "0.15", optional = true }
@@ -24,6 +24,16 @@ fern = { version = "0.6", optional = true }
 tracing-subscriber = { version = "0.3.18", optional = true }
 tracing-chrome = { version = "0.7.1", optional = true }
 tracing = { version = "0.1.40", optional = true }
+
+[dependencies.vapoursynth]
+version = "0.4.0"
+features = [
+  "vsscript-functions",
+  "vapoursynth-functions",
+  "vapoursynth-api-32",
+  "vsscript-api-31",
+]
+optional = true
 
 [features]
 default = ["binary"]
@@ -34,7 +44,7 @@ tracing = [
   "tracing-subscriber",
   "tracing-chrome",
   "dep:tracing",
-  "rav1e/tracing"
+  "rav1e/tracing",
 ]
 
 [[bin]]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,0 +1,40 @@
+use std::io::Read;
+
+use rav1e::{Frame, Pixel};
+
+#[cfg(feature = "vapoursynth")]
+use crate::vapoursynth::VapoursynthDecoder;
+use crate::y4m::VideoDetails;
+
+pub enum Decoder<R: Read> {
+    Y4m(y4m::Decoder<R>),
+    #[cfg(feature = "vapoursynth")]
+    Vapoursynth(VapoursynthDecoder),
+}
+
+impl<R: Read> Decoder<R> {
+    /// # Errors
+    ///
+    /// - If using a Vapoursynth script that contains an unsupported video format.
+    pub fn get_video_details(&self) -> anyhow::Result<VideoDetails> {
+        match self {
+            Decoder::Y4m(dec) => Ok(crate::y4m::get_video_details(dec)),
+            #[cfg(feature = "vapoursynth")]
+            Decoder::Vapoursynth(dec) => dec.get_video_details(),
+        }
+    }
+
+    /// # Errors
+    ///
+    /// - If a frame cannot be read.
+    pub fn read_video_frame<T: Pixel>(
+        &mut self,
+        video_details: &VideoDetails,
+    ) -> anyhow::Result<Frame<T>> {
+        match self {
+            Decoder::Y4m(dec) => crate::y4m::read_video_frame::<R, T>(dec, video_details),
+            #[cfg(feature = "vapoursynth")]
+            Decoder::Vapoursynth(dec) => dec.read_video_frame::<T>(video_details),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,9 @@ use std::{
 };
 
 use anyhow::Result;
-use av_scenechange::{detect_scene_changes, DetectionOptions, SceneDetectionSpeed};
+use av_scenechange::{
+    decoder::Decoder, detect_scene_changes, DetectionOptions, SceneDetectionSpeed,
+};
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -159,12 +161,12 @@ fn main() -> Result<()> {
         _ => panic!("Speed mode must be in range [0; 1]"),
     };
 
-    let mut dec = y4m::Decoder::new(&mut reader)?;
-    let bit_depth = dec.get_bit_depth();
+    let mut dec = Decoder::Y4m(y4m::Decoder::new(&mut reader)?);
+    let bit_depth = dec.get_video_details()?.bit_depth;
     let results = if bit_depth == 8 {
-        detect_scene_changes::<_, u8>(&mut dec, opts, None, None)
+        detect_scene_changes::<_, u8>(&mut dec, opts, None, None)?
     } else {
-        detect_scene_changes::<_, u16>(&mut dec, opts, None, None)
+        detect_scene_changes::<_, u16>(&mut dec, opts, None, None)?
     };
     print!("{}", serde_json::to_string(&results)?);
 

--- a/src/vapoursynth.rs
+++ b/src/vapoursynth.rs
@@ -1,0 +1,191 @@
+use std::{mem::size_of, path::Path, slice};
+
+use anyhow::{bail, ensure};
+use rav1e::{
+    color::{ChromaSamplePosition, ChromaSampling},
+    data::Rational,
+    Frame, Pixel,
+};
+use vapoursynth::{
+    video_info::{Property, VideoInfo},
+    vsscript::{Environment, EvalFlags},
+};
+
+use crate::y4m::VideoDetails;
+
+const OUTPUT_INDEX: i32 = 0;
+
+pub struct VapoursynthDecoder {
+    env: Environment,
+    frames_read: usize,
+    total_frames: usize,
+}
+
+impl VapoursynthDecoder {
+    /// # Errors
+    ///
+    /// - If sourcing an invalid Vapoursynth script.
+    /// - If using a Vapoursynth script that contains an unsupported video format.
+    pub fn new(source: &Path) -> anyhow::Result<VapoursynthDecoder> {
+        let env = Environment::from_file(source, EvalFlags::SetWorkingDir)?;
+        let total_frames = {
+            let (node, _) = env.get_output(OUTPUT_INDEX)?;
+            get_num_frames(node.info())?
+        };
+        Ok(Self {
+            env,
+            frames_read: 0,
+            total_frames,
+        })
+    }
+
+    /// # Errors
+    ///
+    /// - If sourcing an invalid Vapoursynth script.
+    /// - If using a Vapoursynth script that contains an unsupported video format.
+    pub fn get_video_details(&self) -> anyhow::Result<VideoDetails> {
+        let (node, _) = self.env.get_output(OUTPUT_INDEX)?;
+        let info = node.info();
+        let (width, height) = get_resolution(info)?;
+        Ok(VideoDetails {
+            width,
+            height,
+            bit_depth: get_bit_depth(info)?,
+            chroma_sampling: get_chroma_sampling(info)?,
+            chroma_sample_position: ChromaSamplePosition::Unknown,
+            time_base: get_time_base(info)?,
+        })
+    }
+
+    /// # Errors
+    ///
+    /// - If sourcing an invalid Vapoursynth script.
+    /// - If using a Vapoursynth script that contains an unsupported video format.
+    /// - If a frame cannot be read.
+    #[allow(clippy::transmute_ptr_to_ptr)]
+    pub fn read_video_frame<T: Pixel>(&mut self, cfg: &VideoDetails) -> anyhow::Result<Frame<T>> {
+        const SB_SIZE_LOG2: usize = 6;
+        const SB_SIZE: usize = 1 << SB_SIZE_LOG2;
+        const SUBPEL_FILTER_SIZE: usize = 8;
+        const FRAME_MARGIN: usize = 16 + SUBPEL_FILTER_SIZE;
+        const LUMA_PADDING: usize = SB_SIZE + FRAME_MARGIN;
+
+        if self.frames_read >= self.total_frames {
+            bail!("No frames left");
+        }
+
+        let (node, _) = self.env.get_output(OUTPUT_INDEX)?;
+        let vs_frame = node.get_frame(self.frames_read)?;
+        self.frames_read += 1;
+
+        let bytes = size_of::<T>();
+        let mut f: Frame<T> =
+            Frame::new_with_padding(cfg.width, cfg.height, cfg.chroma_sampling, LUMA_PADDING);
+
+        // SAFETY: We are using the stride to compute the length of the data slice
+        unsafe {
+            f.planes[0].copy_from_raw_u8(
+                slice::from_raw_parts(
+                    vs_frame.data_ptr(0),
+                    vs_frame.stride(0) * vs_frame.height(0),
+                ),
+                vs_frame.stride(0),
+                bytes,
+            );
+            f.planes[1].copy_from_raw_u8(
+                slice::from_raw_parts(
+                    vs_frame.data_ptr(1),
+                    vs_frame.stride(1) * vs_frame.height(1),
+                ),
+                vs_frame.stride(1),
+                bytes,
+            );
+            f.planes[2].copy_from_raw_u8(
+                slice::from_raw_parts(
+                    vs_frame.data_ptr(2),
+                    vs_frame.stride(2) * vs_frame.height(2),
+                ),
+                vs_frame.stride(2),
+                bytes,
+            );
+        }
+        Ok(f)
+    }
+}
+
+/// Get the number of frames from a Vapoursynth `VideoInfo` struct.
+fn get_num_frames(info: VideoInfo) -> anyhow::Result<usize> {
+    let num_frames = {
+        if Property::Variable == info.format {
+            bail!("Cannot output clips with varying format");
+        }
+        if Property::Variable == info.resolution {
+            bail!("Cannot output clips with varying dimensions");
+        }
+        if Property::Variable == info.framerate {
+            bail!("Cannot output clips with varying framerate");
+        }
+
+        info.num_frames
+    };
+
+    ensure!(num_frames != 0, "vapoursynth reported 0 frames");
+
+    Ok(num_frames)
+}
+
+/// Get the bit depth from a Vapoursynth `VideoInfo` struct.
+fn get_bit_depth(info: VideoInfo) -> anyhow::Result<usize> {
+    let bits_per_sample = {
+        match info.format {
+            Property::Variable => {
+                bail!("Cannot output clips with variable format");
+            }
+            Property::Constant(x) => x.bits_per_sample(),
+        }
+    };
+
+    Ok(bits_per_sample as usize)
+}
+
+/// Get the resolution from a Vapoursynth `VideoInfo` struct.
+fn get_resolution(info: VideoInfo) -> anyhow::Result<(usize, usize)> {
+    let resolution = {
+        match info.resolution {
+            Property::Variable => {
+                bail!("Cannot output clips with variable resolution");
+            }
+            Property::Constant(x) => x,
+        }
+    };
+
+    Ok((resolution.width, resolution.height))
+}
+
+/// Get the time base (inverse of frame rate) from a Vapoursynth `VideoInfo` struct.
+fn get_time_base(info: VideoInfo) -> anyhow::Result<Rational> {
+    match info.framerate {
+        Property::Variable => bail!("Cannot output clips with varying framerate"),
+        Property::Constant(fps) => Ok(Rational::new(fps.denominator, fps.numerator)),
+    }
+}
+
+/// Get the chroma sampling from a Vapoursynth `VideoInfo` struct.
+fn get_chroma_sampling(info: VideoInfo) -> anyhow::Result<ChromaSampling> {
+    match info.format {
+        Property::Variable => bail!("Variable pixel format not supported"),
+        Property::Constant(x) => match x.color_family() {
+            vapoursynth::format::ColorFamily::YUV => {
+                let ss = (x.sub_sampling_w(), x.sub_sampling_h());
+                match ss {
+                    (1, 1) => Ok(ChromaSampling::Cs420),
+                    (1, 0) => Ok(ChromaSampling::Cs422),
+                    (0, 0) => Ok(ChromaSampling::Cs444),
+                    _ => bail!("Unrecognized chroma subsampling"),
+                }
+            }
+            vapoursynth::format::ColorFamily::Gray => Ok(ChromaSampling::Cs400),
+            _ => bail!("Currently only YUV input is supported"),
+        },
+    }
+}


### PR DESCRIPTION
This is primarily for av1an, but may be useful to other applications as well. Currently, any application wanting to use this library must convert its input to y4m, and the simplest way to do this is to pipe from `vspipe` or `ffmpeg`. This change adds a Vapoursynth decoder, gated behind a Cargo feature (off by default), to allow library consumers to avoid this piping. This provides substantial performance improvements. The amount of improvement varies depending on the source video format, as this moves the bottleneck to be on the decoder, but tests showed anywhere from 20-75% improvement on 8-bit for the fast scenechange method, with smaller but still respectable improvements of up to 20% for 10-bit and for the standard scenechange method, compared to piping from `vspipe`.