### PR TITLE
Update av-decoders from 0.1.0 to 0.2.0 to support VapoursynthDecoder modify_node callback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 aligned = "0.4.2"
 anyhow = "1.0.56"
 arrayvec = "0.7.6"
-av-decoders = { version = "0.1.0" }
+av-decoders = { version = "0.2.0" }
 cfg-if = "1.0.0"
 clap = { version = "4.0.22", optional = true, features = ["derive"] }
 console = { version = "0.16", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ mod data;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    io::Read,
     sync::Arc,
     time::Instant,
 };
@@ -74,8 +73,8 @@ pub struct DetectionResults {
 ///
 /// - If using a Vapoursynth script that contains an unsupported video format.
 #[inline]
-pub fn new_detector<R: Read, T: Pixel>(
-    dec: &mut Decoder<R>,
+pub fn new_detector<T: Pixel>(
+    dec: &mut Decoder,
     opts: DetectionOptions,
 ) -> anyhow::Result<SceneChangeDetector<T>> {
     let video_details = dec.get_video_details();
@@ -119,15 +118,15 @@ pub fn new_detector<R: Read, T: Pixel>(
 ///
 /// - If `opts.lookahead_distance` is 0.
 #[inline]
-pub fn detect_scene_changes<R: Read, T: Pixel>(
-    dec: &mut Decoder<R>,
+pub fn detect_scene_changes<T: Pixel>(
+    dec: &mut Decoder,
     opts: DetectionOptions,
     frame_limit: Option<usize>,
     progress_callback: Option<&dyn Fn(usize, usize)>,
 ) -> anyhow::Result<DetectionResults> {
     assert!(opts.lookahead_distance >= 1);
 
-    let mut detector = new_detector::<R, T>(dec, opts)?;
+    let mut detector = new_detector::<T>(dec, opts)?;
     let mut frame_queue = BTreeMap::new();
     let mut keyframes = BTreeSet::new();
     keyframes.insert(0);


### PR DESCRIPTION
av-decoders now supports a callback that allows users to modify/replace the output node before decoding or evaluating. An example is to downscale the resolution to improve performance without having to modify the input itself.