### PR TITLE
Return scores in DetectionResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.17.0 (unreleased)
 
 - [Breaking] Update the `analyze_next_frame` method to also return the frame scores, if present
+  [Breaking] Update the `DetectionResults` to also return frame scores
 
 ## Version 0.16.0
 

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -405,6 +405,7 @@ impl<T: Pixel> SceneChangeDetector<T> {
 
 /// Contains the scores for scenecut analysis on a single frame
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ScenecutResult {
     inter_cost: f64,
     imp_block_cost: f64,


### PR DESCRIPTION
This allows the simple scenechange interface to also have access to the scores.