### PR TITLE
Bump av-decoders from 0.2.0 to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.17.2 (unreleased)
+
+- Update `av_decoders` create from `0.2.0` to `0.3.0`
+
 ## Version 0.17.1
 
 - Make the fields on `ScenecutResult` public so that it can actually be useful

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "av-decoders"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c903422c1c3efb99fe90ea5e54df3013418090e8ffb8978b2aeefdb39c914e7f"
+checksum = "a3778ec4ac567969eaafbb556bb43a0a34ed21afc51a3c1ec1e467cf727a7dfc"
 dependencies = [
  "ffmpeg-the-third",
  "num-rational",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [".github/*", "benches", "test_files"]
 aligned = "0.4.2"
 anyhow = "1.0.56"
 arrayvec = "0.7.6"
-av-decoders = { version = "0.2.0" }
+av-decoders = { version = "0.3.0" }
 cfg-if = "1.0.0"
 clap = { version = "4.0.22", optional = true, features = ["derive"] }
 console = { version = "0.16", optional = true }


### PR DESCRIPTION
Also add unreleased 0.17.2 to CHANGELOG (Cargo.toml version has not been updated)

No API changes are required. Allows for users downstream to use latest `av-decoders` and its new features.

Thanks,
\- Boats M.