### PR TITLE
Bump av-decoders from 0.3.0 to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.17.3 (unreleased)
+
+- Update `av_decoders` crate from `0.3.0` to `0.4.0`
+
 ## Version 0.17.2
 
 - Update `av_decoders` crate from `0.2.0` to `0.3.0`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "av-decoders"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3778ec4ac567969eaafbb556bb43a0a34ed21afc51a3c1ec1e467cf727a7dfc"
+checksum = "ce3eb4b0697edeafbbb6f15bcf22dde7ae7d8e7449211111a9bbb554862ed9a7"
 dependencies = [
  "ffmpeg-the-third",
  "num-rational",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [".github/*", "benches", "test_files"]
 aligned = "0.4.2"
 anyhow = "1.0.56"
 arrayvec = "0.7.6"
-av-decoders = { version = "0.3.0" }
+av-decoders = { version = "0.4.0" }
 cfg-if = "1.0.0"
 clap = { version = "4.0.22", optional = true, features = ["derive"] }
 console = { version = "0.16", optional = true }

--- a/benches/scd_bench.rs
+++ b/benches/scd_bench.rs
@@ -93,14 +93,14 @@ clip.set_output(0)
         );
         // Create the decoder once to build the index file
         let _ = Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(black_box(
-            VapoursynthDecoder::from_script(&script).unwrap(),
+            VapoursynthDecoder::from_script(&script, None).unwrap(),
         )))
         .unwrap();
 
         b.iter_batched(
             || {
                 let decoder = Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(
-                    black_box(VapoursynthDecoder::from_script(&script).unwrap()),
+                    black_box(VapoursynthDecoder::from_script(&script, None).unwrap()),
                 ))
                 .unwrap();
                 let bit_depth = decoder.get_video_details().bit_depth;

--- a/benches/scd_bench.rs
+++ b/benches/scd_bench.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::unwrap_used)]
 
 use std::{
+    collections::HashMap,
     fs::File,
     hint::black_box,
     io::{BufReader, Read},
@@ -93,14 +94,14 @@ clip.set_output(0)
         );
         // Create the decoder once to build the index file
         let _ = Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(black_box(
-            VapoursynthDecoder::from_script(&script, None).unwrap(),
+            VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap(),
         )))
         .unwrap();
 
         b.iter_batched(
             || {
                 let decoder = Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(
-                    black_box(VapoursynthDecoder::from_script(&script, None).unwrap()),
+                    black_box(VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap()),
                 ))
                 .unwrap();
                 let bit_depth = decoder.get_video_details().bit_depth;

--- a/benches/scd_bench.rs
+++ b/benches/scd_bench.rs
@@ -2,7 +2,6 @@
 #![allow(clippy::unwrap_used)]
 
 use std::{
-    collections::HashMap,
     fs::File,
     hint::black_box,
     io::{BufReader, Read},
@@ -83,6 +82,8 @@ fn y4m_long_benchmark(c: &mut Criterion) {
 #[cfg(feature = "vapoursynth")]
 fn vapoursynth_benchmark(c: &mut Criterion) {
     c.bench_function("vapoursynth detect", |b| {
+        use std::collections::HashMap;
+
         let script = format!(
             r#"
 import vapoursynth as vs


### PR DESCRIPTION
Add 0.17.3 (unreleased) to CHANGELOG

Must be merged *after* merging rust-av/av-decoders#4 which adds optional parameters for `VapoursynthDecoder::from_file()` and `VapoursynthDecoder::from_script()`. `decoders_bench.rs` has been updated to reflect these API changes. The cargo.toml version for `av-decoders` has been updated to what will likely be version 0.4.0. This PR won't build until that is released.

Thanks,
\- Boats M.