### PR TITLE
add maybe-rayon and "threading" feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,11 +162,11 @@ dependencies = [
  "fern",
  "libc",
  "log",
+ "maybe-rayon",
  "nasm-rs",
  "num-rational",
  "num-traits",
  "pastey",
- "rayon",
  "serde",
  "serde_json",
  "thiserror",
@@ -710,6 +710,16 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ log = { version = "0.4.28" }
 num-rational = { version = "0.4.2", default-features = false }
 num-traits = "0.2.19"
 pastey = "0.2.1"
-rayon = "1.11.0"
+rayon = { package = "maybe-rayon", version = "0.1", default-features = false }
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde_json = { version = "1.0.145", optional = true }
 thiserror = "2.0.17"
@@ -64,7 +64,7 @@ cc = { version = "1.2.47", features = ["parallel"], optional = true }
 nasm-rs = { version = "0.3.1", features = ["parallel"], optional = true }
 
 [features]
-default = ["asm", "binary"]
+default = ["asm", "binary", "threading"]
 # Enable platform-specific SIMD for enhanced performance
 asm = ["cc", "libc", "nasm-rs"]
 # Statically compile only the SIMD for the targeted CPU (e.g. only AVX512 for znver4)
@@ -80,6 +80,8 @@ serialize = ["serde", "serde_json"]
 tracing = ["dep:tracing", "tracing-perfetto", "tracing-subscriber"]
 bench-internals = []
 vapoursynth = ["av-decoders/vapoursynth"]
+# Disabling this will remove `rayon` from the dependency tree
+threading = ["rayon/threads"]
 
 [lints.clippy]
 # Correctness/Safety

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ cd av-scenechange
 cargo build --release
 
 # Build without assembly optimizations (no NASM required)
-cargo build --release --no-default-features --features binary
+cargo build --release --no-default-features --features binary,threading
 
 # Build with additional features
 cargo build --release --features ffmpeg  # FFmpeg input support

--- a/src/analyze/inter.rs
+++ b/src/analyze/inter.rs
@@ -6,7 +6,9 @@ use std::{
 use aligned::{A64, Aligned};
 use arrayvec::ArrayVec;
 use num_rational::Rational32;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::iter::IntoParallelIterator;
+#[cfg(feature = "threading")]
+use rayon::iter::ParallelIterator;
 use v_frame::{
     chroma::ChromaSubsampling,
     frame::Frame,


### PR DESCRIPTION
Supersedes #198 (see also image-rs/image#2028). I just copied the way [rav1e](https://github.com/xiph/rav1e/blob/master/Cargo.toml) does it.

It is very important that downstream users that use `default-features = false` manually enable the "threading" feature to keep using real rayon.