### PR TITLE
Update CI and fix rust-toolchain usage 

### DIFF
--- a/.github/workflows/av-scenechange.yml
+++ b/.github/workflows/av-scenechange.yml
@@ -34,7 +34,9 @@ jobs:
       - uses: ilammy/setup-nasm@v1
 
       - name: Install Rust stable
-        run: rustup toolchain install --no-self-update --override stable
+        run: |
+          rustup toolchain install --no-self-update stable
+          rustup override set stable
       - uses: Swatinem/rust-cache@v2
 
       - name: Set MSVC x86_64 linker path

--- a/.github/workflows/av-scenechange.yml
+++ b/.github/workflows/av-scenechange.yml
@@ -15,14 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install nightly
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
+      - name: Install rust-toolchain.toml
+        run: rustup toolchain install --no-self-update
 
       - name: Run rustfmt
-        run: |
-          cargo fmt -- --check
+        run: cargo fmt --check
 
   build:
     needs: [rustfmt]
@@ -36,10 +33,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ilammy/setup-nasm@v1
 
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+      - name: Install Rust stable
+        run: rustup toolchain install --no-self-update --override stable
       - uses: Swatinem/rust-cache@v2
 
       - name: Set MSVC x86_64 linker path
@@ -72,7 +67,8 @@ jobs:
       - uses: ilammy/setup-nasm@v1
 
       - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup toolchain install --no-self-update --profile minimal --override stable
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-llvm-cov

--- a/.github/workflows/av-scenechange.yml
+++ b/.github/workflows/av-scenechange.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ilammy/setup-nasm@v1
 
       - name: Install stable
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ilammy/setup-nasm@v1
 
       - name: Install stable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ pub fn detect_scene_changes<T: Pixel>(
     while frame_limit.map_or_else(|| true, |limit| produced < limit) {
         #[cfg(feature = "tracing")]
         let span = tracing::span!(tracing::Level::INFO, "read_video_frame");
-         #[cfg(feature = "tracing")]
+        #[cfg(feature = "tracing")]
         let enter = span.enter();
         match dec.read_video_frame() {
             Ok(frame) => {


### PR DESCRIPTION
the `dtolnay/rust-toolchain` action doesn't set an override, so it installs stable but any `cargo` command then uses the toolchain from the `.toml` file afterwards, causing errors later on.

Workaround would be to `rustup set override stable` after the action, but if we're doing that, we might aswell just skip the action and install it ourselves.