### PR TITLE
Limit cpufeatures dependency to x86_64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ av-decoders = "0.10.0"
 cfg-if = "1.0.4"
 clap = { version = "4.5.53", features = ["derive"], optional = true }
 console = { version = "0.16.1", optional = true }
-cpufeatures = "0.3"
 fern = { version = "0.7.1", optional = true }
 libc = { version = "0.2.177", optional = true }
 log = { version = "0.4.28" }
@@ -53,6 +52,9 @@ tracing-perfetto = { version = "0.1.5", optional = true }
 tracing-subscriber = { version = "0.3.20", optional = true }
 v_frame = { version = "0.5", features = ["padding_api"] }
 y4m = "0.8.0"
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+cpufeatures = "0.3"
 
 [dev-dependencies]
 criterion = "0.8.0"


### PR DESCRIPTION
cpufeatures is only used by the runtime CPU detection code behind asm_x86_64. Keeping it as an unconditional dependency makes Cargo build it on unsupported architectures such as riscv64, where the crate emits a compile_error:

```
error: This crate works only on `aarch64`, `loongarch64`, `x86`, and `x86-64` targets.
   --> /build/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cpufeatures-0.2.17/src/lib.rs:152:1
    |
152 | compile_error!("This crate works only on `aarch64`, `loongarch64`, `x86`, and `x86-64` targets.");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `cpufeatures` (lib) due to 1 previous error
```