### PR TITLE
chore: replace semisafe with native unsafe methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,6 @@ dependencies = [
  "nasm-rs",
  "num-rational",
  "num-traits",
- "semisafe",
  "serde",
  "serde_json",
  "tracing",
@@ -1012,12 +1011,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "semisafe"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbd946a24ad67c88e0488bbf4d2d292425cda023b26c15dc21be1c89e13daf1"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ log = { version = "0.4.28" }
 num-rational = { version = "0.4.2", default-features = false }
 num-traits = "0.2.19"
 rayon = { package = "maybe-rayon", version = "0.1", default-features = false }
-semisafe = "1.2.0"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde_json = { version = "1.0.145", optional = true }
 tracing = { version = "0.1.41", optional = true }
@@ -191,7 +190,6 @@ transmute_ptr_to_ptr = "warn"
 transmute_undefined_repr = "warn"
 trivial_regex = "warn"
 trivially_copy_pass_by_ref = "warn"
-undocumented_unsafe_blocks = "warn"
 # Annoyances
 uninlined_format_args = "allow"
 unnecessary_box_returns = "warn"

--- a/src/analyze/importance.rs
+++ b/src/analyze/importance.rs
@@ -64,16 +64,18 @@ fn sum_8x8_block<T: Pixel>(plane: &Plane<T>, x: usize, y: usize) -> i64 {
 #[cfg(any(not(asm_x86_64), test))]
 fn sum_8x8_block_rust<T: Pixel>(plane: &Plane<T>, x: usize, y: usize) -> i64 {
     use crate::data::pixel_as_u32;
-    use semisafe::slice::get;
 
     // Coordinates of the top-left corner of the reference block, in MV units.
     let x = x * IMPORTANCE_BLOCK_SIZE;
     let y = y * IMPORTANCE_BLOCK_SIZE;
 
-    let data = get(plane.data(), plane.geometry().data_origin()..);
+    let data = unsafe { plane.data().get_unchecked(plane.geometry().data_origin()..) };
     let stride = plane.geometry().stride();
     (y..(y + 8)).fold(0, |acc, row_idx| {
-        let row = get(get(data, (x + row_idx * stride)..), ..IMPORTANCE_BLOCK_SIZE);
+        let row = unsafe {
+            data.get_unchecked((x + row_idx * stride)..)
+                .get_unchecked(..IMPORTANCE_BLOCK_SIZE)
+        };
         // 16-bit precision is sufficient for an 8 px row,
         // as `IMPORTANCE_BLOCK_SIZE * (2^12 - 1) < 2^16 - 1`,
         // so overflow is not possible

--- a/src/analyze/intra.rs
+++ b/src/analyze/intra.rs
@@ -26,7 +26,6 @@ use crate::data::{
     superblock::MI_SIZE_LOG2,
     tile::TileRect,
 };
-use semisafe::slice::{get, get_mut};
 
 pub const BLOCK_TO_PLANE_SHIFT: usize = MI_SIZE_LOG2;
 
@@ -152,25 +151,32 @@ pub fn get_intra_edges<'a, T: Pixel>(
             } else {
                 tx_size.height()
             };
-            if x != 0 {
-                for i in 0..txh {
-                    debug_assert!(y + i < rect_h);
-                    get_mut(left, 2 * MAX_TX_SIZE - 1 - i).write(*get(&dst[y + i], x - 1));
-                }
-                if txh < tx_size.height() {
-                    let val = *get(&dst[y + txh - 1], x - 1);
-                    for i in txh..tx_size.height() {
-                        get_mut(left, 2 * MAX_TX_SIZE - 1 - i).write(val);
+            unsafe {
+                if x != 0 {
+                    for i in 0..txh {
+                        debug_assert!(y + i < rect_h);
+
+                        left.get_unchecked_mut(2 * MAX_TX_SIZE - 1 - i)
+                            .write(*dst[y + i].get_unchecked(x - 1));
                     }
-                }
-            } else {
-                let val = if y != 0 {
-                    *get(&dst[y - 1], 0)
+                    if txh < tx_size.height() {
+                        let val = *dst[y + txh - 1].get_unchecked(x - 1);
+                        for i in txh..tx_size.height() {
+                            left.get_unchecked_mut(2 * MAX_TX_SIZE - 1 - i).write(val);
+                        }
+                    }
                 } else {
-                    pixel_from_u16(base + 1)
-                };
-                for v in get_mut(left, 2 * MAX_TX_SIZE - tx_size.height()..).iter_mut() {
-                    v.write(val);
+                    let val = if y != 0 {
+                        *dst[y - 1].get_unchecked(0)
+                    } else {
+                        pixel_from_u16(base + 1)
+                    };
+                    for v in left
+                        .get_unchecked_mut(2 * MAX_TX_SIZE - tx_size.height()..)
+                        .iter_mut()
+                    {
+                        v.write(val);
+                    }
                 }
             }
             init_left += tx_size.height();
@@ -183,34 +189,36 @@ pub fn get_intra_edges<'a, T: Pixel>(
             } else {
                 tx_size.width()
             };
-            if y != 0 {
-                get_mut(above, ..txw).copy_from_slice(
-                    // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
-                    unsafe {
-                        &*(get(&dst[y - 1], x..x + txw) as *const [T]
-                            as *const [std::mem::MaybeUninit<T>])
-                    },
-                );
-                if txw < tx_size.width() {
-                    let val = *get(&dst[y - 1], x + txw - 1);
-                    for v in get_mut(above, txw..tx_size.width()) {
+            unsafe {
+                if y != 0 {
+                    above.get_unchecked_mut(..txw).copy_from_slice(
+                        // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
+                        &*(dst[y - 1].get_unchecked(x..x + txw) as *const [T]
+                            as *const [std::mem::MaybeUninit<T>]),
+                    );
+                    if txw < tx_size.width() {
+                        let val = *dst[y - 1].get_unchecked(x + txw - 1);
+                        for v in above.get_unchecked_mut(txw..tx_size.width()) {
+                            v.write(val);
+                        }
+                    }
+                } else {
+                    let val = if x != 0 {
+                        *dst[0].get_unchecked(x - 1)
+                    } else {
+                        pixel_from_u16(base - 1)
+                    };
+                    for v in above.get_unchecked_mut(..tx_size.width()) {
                         v.write(val);
                     }
-                }
-            } else {
-                let val = if x != 0 {
-                    *get(&dst[0], x - 1)
-                } else {
-                    pixel_from_u16(base - 1)
-                };
-                for v in get_mut(above, ..tx_size.width()) {
-                    v.write(val);
                 }
             }
             init_above += tx_size.width();
         }
 
-        get_mut(top_left, 0).write(pixel_from_u16(base));
+        unsafe {
+            top_left.get_unchecked_mut(0).write(pixel_from_u16(base));
+        }
     }
     IntraEdge::new(edge_buf, init_left, init_above)
 }

--- a/src/analyze/intra/rust.rs
+++ b/src/analyze/intra/rust.rs
@@ -1,4 +1,3 @@
-use semisafe::slice::{get, get_mut};
 use v_frame::pixel::Pixel;
 
 use super::IntraEdge;
@@ -21,7 +20,7 @@ pub(super) fn predict_dc_intra_internal<T: Pixel>(
     let (left, _top_left, above) = edge_buf.as_slices();
 
     let above_slice = above;
-    let left_slice = get(left, left.len().saturating_sub(height)..);
+    let left_slice = unsafe { left.get_unchecked(left.len().saturating_sub(height)..) };
 
     (match variant {
         PredictionVariant::NONE => pred_dc_128,
@@ -39,13 +38,18 @@ fn pred_dc<T: Pixel>(
     height: usize,
     _bit_depth: usize,
 ) {
-    let edges = get(left, ..height).iter().chain(get(above, ..width).iter());
-    let len = (width + height) as u32;
-    let avg = (edges.fold(0u32, |acc, &v| pixel_as_u32(v) + acc) + (len >> 1)) / len;
-    let avg = pixel_from_u16(avg as u16);
+    unsafe {
+        let edges = left
+            .get_unchecked(..height)
+            .iter()
+            .chain(above.get_unchecked(..width).iter());
+        let len = (width + height) as u32;
+        let avg = (edges.fold(0u32, |acc, &v| pixel_as_u32(v) + acc) + (len >> 1)) / len;
+        let avg = pixel_from_u16(avg as u16);
 
-    for line in output.rows_iter_mut().take(height) {
-        get_mut(line, ..width).fill(avg);
+        for line in output.rows_iter_mut().take(height) {
+            line.get_unchecked_mut(..width).fill(avg);
+        }
     }
 }
 
@@ -59,7 +63,9 @@ fn pred_dc_128<T: Pixel>(
 ) {
     let v = pixel_from_u16((128u32 << (bit_depth - 8)) as u16);
     for line in output.rows_iter_mut().take(height) {
-        get_mut(line, ..width).fill(v);
+        unsafe {
+            line.get_unchecked_mut(..width).fill(v);
+        }
     }
 }
 
@@ -74,7 +80,9 @@ fn pred_dc_left<T: Pixel>(
     let sum = left.iter().fold(0u32, |acc, &v| pixel_as_u32(v) + acc);
     let avg = pixel_from_u16(((sum + (height >> 1) as u32) / height as u32) as u16);
     for line in output.rows_iter_mut().take(height) {
-        get_mut(line, ..width).fill(avg);
+        unsafe {
+            line.get_unchecked_mut(..width).fill(avg);
+        }
     }
 }
 
@@ -86,11 +94,13 @@ fn pred_dc_top<T: Pixel>(
     height: usize,
     _bit_depth: usize,
 ) {
-    let sum = get(above, ..width)
+    let sum = unsafe { above.get_unchecked(..width) }
         .iter()
         .fold(0u32, |acc, &v| pixel_as_u32(v) + acc);
     let avg = pixel_from_u16(((sum + (width >> 1) as u32) / width as u32) as u16);
     for line in output.rows_iter_mut().take(height) {
-        get_mut(line, ..width).fill(avg);
+        unsafe {
+            line.get_unchecked_mut(..width).fill(avg);
+        }
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,6 +1,5 @@
 use std::mem::MaybeUninit;
 
-use semisafe::result::unwrap as res_unwrap;
 use v_frame::pixel::Pixel;
 
 pub(crate) mod block;
@@ -35,5 +34,5 @@ pub(crate) fn pixel_as_u32<T: Pixel>(pixel: T) -> u32 {
 
 #[inline]
 pub(crate) fn pixel_from_u16<T: Pixel>(value: u16) -> T {
-    res_unwrap(T::try_from(value))
+    unsafe { T::try_from(value).unwrap_unchecked() }
 }

--- a/src/data/motion.rs
+++ b/src/data/motion.rs
@@ -9,8 +9,6 @@ use std::{
 use arrayvec::ArrayVec;
 use v_frame::{frame::Frame, pixel::Pixel, plane::Plane};
 
-use semisafe::slice::{get, get_mut};
-
 const MV_IN_USE_BITS: usize = 14;
 pub const MV_UPP: i32 = 1 << MV_IN_USE_BITS;
 pub const MV_LOW: i32 = -(1 << MV_IN_USE_BITS);
@@ -138,14 +136,20 @@ impl Index<usize> for FrameMEStats {
     type Output = [MEStats];
 
     fn index(&self, index: usize) -> &Self::Output {
-        get(&self.stats, index * self.cols..(index + 1) * self.cols)
+        unsafe {
+            self.stats
+                .get_unchecked(index * self.cols..(index + 1) * self.cols)
+        }
     }
 }
 
 #[allow(clippy::missing_inline_in_public_items)]
 impl IndexMut<usize> for FrameMEStats {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        get_mut(&mut self.stats, index * self.cols..(index + 1) * self.cols)
+        unsafe {
+            self.stats
+                .get_unchecked_mut(index * self.cols..(index + 1) * self.cols)
+        }
     }
 }
 


### PR DESCRIPTION
Since these have builtin unsafe assertions, the semisafe crate is largely unnecessary, although it does mean we need to throw `unsafe` everywhere, but that's probably better.